### PR TITLE
APIMF-2369: added support for detecting JSON duplicate keys. Default behaviour is the same for SYAML.

### DIFF
--- a/shared/src/main/scala/org/yaml/model/DefaultJsonErrorHandler.scala
+++ b/shared/src/main/scala/org/yaml/model/DefaultJsonErrorHandler.scala
@@ -1,0 +1,18 @@
+package org.yaml.model
+import org.mulesoft.lexer.SourceLocation
+
+trait DefaultJsonErrorHandler extends ParseErrorHandler {
+
+  protected val errorHandler: ParseErrorHandler = ParseErrorHandler.parseErrorHandler
+
+  override def handle(location: SourceLocation, e: SyamlException): Unit = e match {
+    case _: DuplicateKeyException => onIgnoredException(location, e)
+    case _                        => errorHandler.handle(location, e)
+  }
+
+  protected def onIgnoredException(location: SourceLocation, e: SyamlException): Unit = Unit
+}
+
+object DefaultJsonErrorHandler {
+  def apply(): DefaultJsonErrorHandler = new DefaultJsonErrorHandler {}
+}

--- a/shared/src/main/scala/org/yaml/parser/DuplicateDetection.scala
+++ b/shared/src/main/scala/org/yaml/parser/DuplicateDetection.scala
@@ -1,0 +1,22 @@
+package org.yaml.parser
+
+import org.yaml.model._
+
+import scala.collection.mutable
+
+trait DuplicateDetection {
+
+  def duplicates(parts: Array[YPart])(implicit errorHandler: ParseErrorHandler): Unit = {
+    val keys = mutable.Set[String]()
+    for (part <- parts) part match {
+      case entry: YMapEntry =>
+        entry.key.value match {
+          case s: YScalar =>
+            val key = s.text
+            if (!keys.add(key)) errorHandler.handle(entry.key.location, DuplicateKeyException(key))
+          case _ =>
+        }
+      case _ =>
+    }
+  }
+}

--- a/shared/src/main/scala/org/yaml/parser/JsonParser.scala
+++ b/shared/src/main/scala/org/yaml/parser/JsonParser.scala
@@ -11,7 +11,10 @@ import scala.collection.mutable.ArrayBuffer
 /**
   * A Json Parser
   */
-class JsonParser private[parser] (val lexer: JsonLexer)(implicit val eh: ParseErrorHandler) extends YParser {
+class JsonParser private[parser] (val lexer: JsonLexer)(
+    implicit val eh: ParseErrorHandler)
+    extends YParser
+    with DuplicateDetection {
 
   type TD = TokenData[YamlToken]
 
@@ -96,7 +99,8 @@ class JsonParser private[parser] (val lexer: JsonLexer)(implicit val eh: ParseEr
     if (r) consume()
 
     val parts = current.buildParts()
-    val v     = YMap(sl, parts)
+    duplicates(parts)
+    val v = YMap(sl, parts)
     stackParts(buildNode(v, YType.Map.tag))
     r
   }
@@ -359,18 +363,18 @@ class JsonParser private[parser] (val lexer: JsonLexer)(implicit val eh: ParseEr
 }
 
 object JsonParser {
-  def apply(s: CharSequence)(implicit eh: ParseErrorHandler = ParseErrorHandler.parseErrorHandler): JsonParser =
+  def apply(s: CharSequence)(implicit eh: ParseErrorHandler = DefaultJsonErrorHandler()): JsonParser =
     new JsonParser(JsonLexer(s))(eh)
 
-  def obj(s: CharSequence)(implicit eh: ParseErrorHandler = ParseErrorHandler.parseErrorHandler): YObj =
+  def obj(s: CharSequence)(implicit eh: ParseErrorHandler = DefaultJsonErrorHandler()): YObj =
     apply(s)(eh).document().obj
 
   def withSource(s: CharSequence, sourceName: String, positionOffset: Position = Position.Zero)(
-      implicit eh: ParseErrorHandler = ParseErrorHandler.parseErrorHandler): JsonParser =
+      implicit eh: ParseErrorHandler = DefaultJsonErrorHandler()): JsonParser =
     new JsonParser(JsonLexer(s, sourceName, positionOffset))(eh)
 
   @deprecated("Use Position argument", "")
   def withSourceOffset(s: CharSequence, sourceName: String, offset: (Int, Int))(
-      implicit eh: ParseErrorHandler = ParseErrorHandler.parseErrorHandler): JsonParser =
+      implicit eh: ParseErrorHandler = DefaultJsonErrorHandler()): JsonParser =
     withSource(s, sourceName, Position(offset._1, offset._2))
 }

--- a/shared/src/main/scala/org/yaml/parser/YamlLoader.scala
+++ b/shared/src/main/scala/org/yaml/parser/YamlLoader.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 private[parser] class YamlLoader(val lexer: YamlLexer,
                                  val keepTokens: Boolean,
                                  val includeTag: String,
-                                 implicit val eh: ParseErrorHandler) {
+                                 implicit val eh: ParseErrorHandler) extends DuplicateDetection {
 
   private val aliases              = mutable.Map.empty[String, YNode]
   private def current: YamlBuilder = stack.top()
@@ -73,20 +73,6 @@ private[parser] class YamlLoader(val lexer: YamlLexer,
       case _           =>
     }
     current.addCurrentToken()
-  }
-
-  private def duplicates(parts: Array[YPart]): Unit = {
-    val keys = mutable.Set[String]()
-    for (part <- parts) part match {
-      case entry: YMapEntry =>
-        entry.key.value match {
-          case s: YScalar =>
-            val key = s.text
-            if (!keys.add(key)) eh.handle(entry.key.location, DuplicateKeyException(key))
-          case _ =>
-        }
-      case _ =>
-    }
   }
 
   private class YamlBuilder(val first: SourceLocation = lexer.tokenData.range) {


### PR DESCRIPTION
Related to: 
- https://github.com/aml-org/amf-core/pull/101
- https://github.com/aml-org/amf/pull/618